### PR TITLE
Replace hard coded footers in contents with a content filter

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -14,3 +14,6 @@ categories:
 filters:
   hostedFiles:
     baseUrl: https://sinch.github.io/docs/
+  footer:
+    template: templates/footer.mustache
+    baseUrl: https://github.com/sinch/docs/blob/master/docs/

--- a/lib/README.md
+++ b/lib/README.md
@@ -76,13 +76,53 @@ Paths are assumed to be specified as relative to the page in which the files are
 | `baseUrl` | The base URL where the files are publicly available |
 
 
-**Example YAML configuration**
+**Example `config.yml` configuration**
 
 ```yaml
 filters:
   - hostedFiles:
       baseUrl: https://GITHUB_USERNAME.github.io/REPO/
 ```
+
+#### `footer`
+
+Renders a Mustache template as the footer of all content files.
+
+The Mustache template is rendered with a [view]() object that includes the following attributes:
+
+| Attribute | Description                                                                               |
+| ---       | ---                                                                                       |
+| `page`    | The page object being rendered. See the `Page` class for details of available attributes. |
+
+Additionally, all of the filter's configuration attributes are passed to the template so they can be used directly.
+
+**Configuration attributes**:
+
+| Field      | Description                                                                                                            |
+| ---        | ---                                                                                                                    |
+| `template` | Path to the Mustache template that will be rendered as the footer for every page, relative to the project's directory. |
+
+**Example `config.yml` configuration**
+
+```yaml
+filters:
+  - footer:
+      template: templates/footer.mustache
+      someAttribute: Hello there!
+```
+
+Given the above configuration and the following Mustache template:
+
+```html
+<span id="footer">{{someAttribute}}</span>
+``` 
+
+The following footer would be rendered on each content page:
+
+```html
+<span id="footer">Hello there!</span>
+```
+
 
 ### Get help
 

--- a/lib/catalog.js
+++ b/lib/catalog.js
@@ -206,6 +206,11 @@ ${this.content}`;
         });
     }
 
+    edit(content) {
+        this.content = content;
+        return this;
+    }
+
     static create({category, parent, slug, sources}) {
         const matter = frontMatter(sources);
         return new Page(category, parent, slug, matter.content, matter.data);

--- a/lib/filters.js
+++ b/lib/filters.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const fs = require('fs');
 const { URL } = require('url');
 
 const { UrlLink } = require('./catalog');
@@ -17,14 +18,14 @@ const { UrlLink } = require('./catalog');
  */
 class Filter {
     constructor(config) {
-        this.baseUrl = config.baseUrl;
+        this.config = config;
     }
 
-    apply(page) {
+    async apply(page) {
         throw new Error("Not implemented");
     }
 
-    rollback(page) {
+    async rollback(page) {
         throw new Error("Not implemented");
     }
 }
@@ -45,29 +46,95 @@ class HostedFilesFilter extends Filter {
 
         for (const link of page.links.filter(link => link instanceof UrlLink && link.isLocal())) {
             const localFilePath = path.join(page.directory, link.href);
-            const hostingUrl = new URL(localFilePath, this.baseUrl);
+            const hostingUrl = new URL(localFilePath, this.config.baseUrl);
 
             replacements.push([link, link.copy({href: hostingUrl.toString()})]);
         }
-        return page.replaceElements(replacements);
+        return Promise.resolve(page.replaceElements(replacements));
     }
 
     rollback(page) {
         const replacements = [];
 
         for (const link of page.links.filter(link => link instanceof UrlLink && link.isRemote())) {
-            if (link.href.startsWith(this.baseUrl)) {
-                const localFilePath = decodeURI(link.href.substr(this.baseUrl.length));
+            if (link.href.startsWith(this.config.baseUrl)) {
+                const localFilePath = decodeURI(link.href.substr(this.config.baseUrl.length));
                 const relativePath = path.relative(page.directory, localFilePath);
 
                 replacements.push([link, link.copy({href: relativePath})]);
             }
         }
-        return page.replaceElements(replacements);
+        return Promise.resolve(page.replaceElements(replacements));
+    }
+}
+
+/**
+ *
+ * todo: individual filters should be put in separate source files.
+ */
+const Mustache = require('mustache');
+const { asyncStringReplace } = require("./tools");
+
+/**
+ * Represents a section of content that is marked so that it can be located easily and reliably.
+ * Stub Markdown "comments" are used to delimit content as described here: https://stackoverflow.com/questions/4823468/comments-in-markdown
+ */
+class ContentMarker {
+    constructor(name) {
+        this.name = name;
+        this.regex = new RegExp(`\\n\\[${name}\\]: #((.|[\\r\\n])*)\\[\\/${name}\\]: #`, 'gm');
+    }
+
+    wrap(content) {
+        return `\n[${this.name}]: #\n${content}\n\n[/${this.name}]: #`;
+    }
+
+    async replaceAll(content, replacementFn) {
+        return await asyncStringReplace(content, this.regex, replacementFn);
+    }
+}
+
+
+/**
+ * Renders a Mustache template as the footer of all content files.
+ *
+ * The Mustache template is rendered with an object that includes the following attributes:
+ *
+ *  - `page`: The page object being rendered.
+ *
+ * Additionally, all of the filter's configuration attributes are also passed to the template so they can be used
+ * directly.
+ */
+class FooterFilter extends Filter {
+    constructor(config) {
+        super(config);
+        this.marker = new ContentMarker('footer');
+    }
+
+    apply(page) {
+        const view = {
+            page,
+            ...this.config,
+        };
+
+        return new Promise((resolve, reject) => {
+            fs.readFile(this.config.template, (err, data) => {
+                if (err) reject(err);
+
+                const rendered = Mustache.render(data.toString(), view);
+                resolve(page.edit(page.content + this.marker.wrap(rendered)));
+            });
+        });
+    }
+
+    async rollback(page) {
+        const newContent = await this.marker.replaceAll(page.content, () => '');
+        return page.edit(newContent);
     }
 }
 
 
 module.exports = {
     hostedFiles: HostedFilesFilter,
+    footer: FooterFilter,
 };

--- a/lib/markdownize.js
+++ b/lib/markdownize.js
@@ -2,6 +2,7 @@ const chalk = require('chalk');
 const path = require('path');
 const fs = require('fs');
 const request = require('request');
+const { asyncStringReplace } = require("./tools");
 
 const conversions = {
     code: codeBlockToMarkdown,
@@ -134,25 +135,4 @@ async function imageToMarkdown(json, page, options) {
         markdown += `\n`;
     }
     return markdown;
-}
-
-async function asyncStringReplace(str, regex, replacementFn) {
-    const substrs = [];
-    let lastMatchPosition = 0;
-    let match;
-    while ((match = regex.exec(str)) !== null) {
-        // push the part that wasn't a match
-        substrs.push(str.slice(lastMatchPosition, match.index));
-
-        // push the async replacement
-        substrs.push(replacementFn(...match));
-
-        // update pointer
-        lastMatchPosition = regex.lastIndex;
-    }
-    // put the remainder of str that did not match
-    substrs.push(str.slice(lastMatchPosition));
-
-    // wait for async calls to finish and join them back into final string
-    return (await Promise.all(substrs)).join('');
 }

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -26,6 +26,37 @@ async function fileExists(path) {
     });
 }
 
+/**
+ * Asynchronously replaces all occurrences of content that match a regex in a source content string.
+ * For every part of the content that matches the regex, the replacement function will be called with the
+ * Regex match object. That function is expected to process the matched block and return a replacement value.
+ * @param str the source string
+ * @param regex the regex that will be used to find content
+ * @param replacementFn The function that will be called to perform a specific replacement.
+ * @returns {Promise<string>} A Promise of the resulting string where all matches have been replaced.
+ */
+async function asyncStringReplace(str, regex, replacementFn) {
+    const substrs = [];
+    let lastMatchPosition = 0;
+    let match;
+    while ((match = regex.exec(str)) !== null) {
+        // push the part that wasn't a match
+        substrs.push(str.slice(lastMatchPosition, match.index));
+
+        // push the async replacement
+        substrs.push(replacementFn(...match));
+
+        // update pointer
+        lastMatchPosition = regex.lastIndex;
+    }
+    // put the remainder of str that did not match
+    substrs.push(str.slice(lastMatchPosition));
+
+    // wait for async calls to finish and join them back into final string
+    return (await Promise.all(substrs)).join('');
+}
+
 
 module.exports.flatten = flatten;
 module.exports.fileExists = fileExists;
+module.exports.asyncStringReplace = asyncStringReplace;

--- a/package-lock.json
+++ b/package-lock.json
@@ -383,6 +383,11 @@
         "brace-expansion": "^1.1.7"
       }
     },
+    "mustache": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-3.1.0.tgz",
+      "integrity": "sha512-3Bxq1R5LBZp7fbFPZzFe5WN4s0q3+gxZaZuZVY+QctYJiCiVgXHOTIC0/HgZuOPFt/6BQcx5u0H2CUOxT/RoGQ=="
+    },
     "oauth-sign": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "gray-matter": "^4.0.2",
     "js-yaml": "^3.13.1",
     "marked": "^0.7.0",
+    "mustache": "^3.1.0",
     "readline-sync": "^1.4.10",
     "request": "^2.88.0",
     "request-promise-native": "^1.0.7",

--- a/readme.js
+++ b/readme.js
@@ -76,7 +76,7 @@ locally but not present on Readme). If any are found, the program will offer to 
 
         let fetchedPages = await readme.fetchPages(listCategories(slug, options.config), async page => {
             for (const filter of createFilters(options.config)) {
-                page = filter.rollback(page);
+                page = await filter.rollback(page);
             }
 
             const outputFile = await page.writeTo(cmd.dir);
@@ -130,7 +130,7 @@ program
         const readme = apiClient(catalog, options);
         for (let page of catalog.pages) {
             for (const filter of createFilters(options.config)) {
-                page = filter.apply(page);
+                page = await filter.apply(page);
             }
 
             readme.pushPage(page);

--- a/readme.js
+++ b/readme.js
@@ -259,27 +259,6 @@ All validations are performed unless --validations is specified.
         });
     });
 
-    program
-    .command('insertanchors', )
-    .description(`Insert "Edit on GitHub" anchors at bottom of files`)
-    .action( () => {
-        walk('docs', function(filePath, stat) {
-            if(path.extname(filePath) == '.md'){
-                var url = BASE_GITURL + filePath;
-                fs.readFile(filePath, function(err, data){
-                    if(err) console.log('There was an error reading the file!', err);
-                    if(!data.includes(url)){
-                        let anchor = `\n\n<a class="gitbutton pill" target="_blank" href="${url}"><span class="fab fa-github"></span>Edit on GitHub</a>`
-                        fs.appendFile(filePath, anchor, function(err) {
-                            err ? console.log(err) : console.log(chalk.green(`The url ${url} has been appendended to the end of the file ${filePath}`))
-                        })
-                    }
-                })
-            }
-        });
-    }
-    );
-
 program.parse(process.argv);
 
 async function walk(currentDirPath, callback) {

--- a/templates/footer.mustache
+++ b/templates/footer.mustache
@@ -1,0 +1,1 @@
+<a class="gitbutton pill" target="_blank" href="{{{baseUrl}}}{{{page.path}}}"><span class="fab fa-github"></span>Edit on GitHub</a>


### PR DESCRIPTION
The hardcoded footers have temporarily been removed from the content files in the `master` branch with this commit to make the review easier: 2509f43ae440df8ff42b2fff24d9d52444b78651

As soon as this PR is merged to `master`, the **Edit on GitHub** links will be re-added but this time they'll be automatically rendered by the filter.

Addresses #9 