### PR TITLE
Add support for hidden pages

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -10,6 +10,9 @@ categories:
   - tutorials
   - contributing-guidelines
   - release-notes
+  - atlas-platform
+  - sinch-classic-sms
+  - voice-cloud
 
 filters:
   hostedFiles:

--- a/docs/atlas-platform/atlas-messaging-service-platform.md
+++ b/docs/atlas-platform/atlas-messaging-service-platform.md
@@ -1,6 +1,7 @@
 ---
 title: "Atlas Messaging Service Platform"
 excerpt: ""
+hidden: "true"
 ---
 
 

--- a/docs/atlas-platform/atlas-messaging-service-platform/http-sms.md
+++ b/docs/atlas-platform/atlas-messaging-service-platform/http-sms.md
@@ -1,6 +1,7 @@
 ---
 title: "HTTP SMS"
 excerpt: ""
+hidden: "true"
 ---
 ## Introduction
 

--- a/docs/sinch-classic-sms/sms-classic.md
+++ b/docs/sinch-classic-sms/sms-classic.md
@@ -1,8 +1,8 @@
 ---
 title: "Sinch Classic SMS"
 excerpt: "This service documentation guide will assist you in setting up standard SMS service which is used for sending regular messages, notifications and marketing campaigns. Please refer to our [Verification documentation](doc:verification-introduction) if you are looking to verify users by SMS using OTP (One-time password) codes."
+hidden: "true"
 ---
-
 This document provides a detailed user guide and reference documentation on the Sinch SMS REST API. For general information on how to use the Sinch APIs including methods, types, errors and authorization, please check the [Using REST](doc:using-rest) page.
 
 ## Overview

--- a/docs/voice-cloud/voice-cloud-callback-api.md
+++ b/docs/voice-cloud/voice-cloud-callback-api.md
@@ -1,8 +1,8 @@
 ---
 title: "Callback API"
 excerpt: ""
+hidden: "true"
 ---
-
 ## Overview
 
 Controlling a call from your application backend is done by responding to callbacks from the Sinch platform and/or by calling REST APIs in the Sinch platform from your application’s backend. The figure that follows illustrates the lifecycle of a call and shows where both callbacks and REST API calls are located or can be made.

--- a/docs/voice-cloud/voice-cloud-calling-api.md
+++ b/docs/voice-cloud/voice-cloud-calling-api.md
@@ -1,8 +1,8 @@
 ---
 title: "Calling API"
 excerpt: ""
+hidden: "true"
 ---
-
 ## Overview
 
 ### Methods

--- a/docs/voice-cloud/voice-cloud-cdr.md
+++ b/docs/voice-cloud/voice-cloud-cdr.md
@@ -1,8 +1,8 @@
 ---
 title: "Call Detail Records"
 excerpt: ""
+hidden: "true"
 ---
-
 CDRs can be downloaded from the Sinch portal. CDRs are in a semicolon separated file that contains the following fields:
 
 ## Phone-terminated calls

--- a/docs/voice-cloud/voice-cloud-intro.md
+++ b/docs/voice-cloud/voice-cloud-intro.md
@@ -1,8 +1,8 @@
 ---
 title: "Introduction"
 excerpt: "Send messages via WhatsApp with Sinch WhatsApp API."
+hidden: "true"
 ---
-
 This document provides a detailed user guide and reference documentation on the Sinch Voice REST API. For general information on how to use the Sinch APIs including methods, types, errors and authorization, please check the [Using REST](doc:using-rest) page.
 
 ## Overview

--- a/docs/voice-cloud/voice-cloud-ivr.md
+++ b/docs/voice-cloud/voice-cloud-ivr.md
@@ -1,8 +1,8 @@
 ---
 title: "Interactive Voice Response"
 excerpt: ""
+hidden: "true"
 ---
-
 The Sinch platform supports playing audio recordings during a call.
 
 ## External media support

--- a/docs/voice-cloud/voice-cloud-misc.md
+++ b/docs/voice-cloud/voice-cloud-misc.md
@@ -1,8 +1,8 @@
 ---
 title: "Glossary"
 excerpt: ""
+hidden: "true"
 ---
-
 | Term       | Explanation                                             |
 | ---------- | ------------------------------------------------------- |
 | RTC        | Real Time Communication                                 |

--- a/docs/voice-cloud/voice-cloud-recording.md
+++ b/docs/voice-cloud/voice-cloud-recording.md
@@ -1,8 +1,8 @@
 ---
 title: "Recording calls"
 excerpt: ""
+hidden: "true"
 ---
-
 ## Overview
 
 With the Sinch platform, you’re able to control the recording of the calls using either the callbacks or the Manage Call API.

--- a/docs/voice-cloud/voice-cloud-reporting-api.md
+++ b/docs/voice-cloud/voice-cloud-reporting-api.md
@@ -1,9 +1,9 @@
 ---
 title: "Call Report"
 excerpt: ""
+hidden: "true"
 ---
-
-    [URL]
+[URL]
         https://reportingapi.sinch.com/[version]
 
     Current version is "v1"

--- a/lib/api-client.js
+++ b/lib/api-client.js
@@ -111,7 +111,6 @@ class Api {
                     json: Object.assign(pageJson, {
                         ...localPage.headers,
                         body: localPage.content,
-                        hidden: false,
                         lastUpdatedHash: localPage.hash,
                     }),
                 });
@@ -171,9 +170,9 @@ class Api {
      */
     static jsonToPage(json, category, parent) {
         const headers = {
-            id: json._id,
             title: json.title,
             excerpt: json.excerpt,
+            hidden: json.hidden,
         };
         return new Page(category, parent ? parent.slug : null, json.slug, json.body, headers);
     }

--- a/lib/catalog.js
+++ b/lib/catalog.js
@@ -124,6 +124,10 @@ class Page {
         return this.headers.excerpt;
     }
 
+    get hidden() {
+        return this.headers.hidden === undefined ? false : this.headers.hidden;
+    }
+
     findElement(filter) {
         return this.elements.find(filter);
     }
@@ -156,16 +160,28 @@ class Page {
         }
 
         return [
-            this.headers.title,
-            this.headers.excerpt,
+            this.title,
+            this.excerpt,
+            this.hidden,
             content
         ].join('\n');
     }
 
     get sources() {
+        const frontmatterEntries = [
+            ['title', this.title],
+            ['excerpt', this.excerpt],
+        ];
+        if (this.hidden) {
+            frontmatterEntries.push(
+                ['hidden', 'true']
+            )
+        }
+
+        const frontMatter = frontmatterEntries.map(([key, value]) => `${key}: "${value}"`).join('\n');
+
         return `---
-title: "${this.headers.title}"
-excerpt: "${this.headers.excerpt}"
+${frontMatter}
 ---
 ${this.content}`;
     }


### PR DESCRIPTION
The sync tool will now make sure the `hidden` flag in the Readme API is updated according to the value in the Markdown front matter.

Syncing of pages in categories `sms-classic-sinch`, `voice-cloud` and `atlas-platform` has been re-enabled.

Addresses #8 