### PR TITLE
Revert change that made sample signature incorrect

### DIFF
--- a/docs/voice/using-rest.md
+++ b/docs/voice/using-rest.md
@@ -243,7 +243,7 @@ The Sinch Platform can initiate callback requests to a URL you define (_Callback
 
 *Example*
 
-E.g. given that _Callback URL_ is configured as `"https://callbacks.yourdomain.com/sinch/callback"`
+E.g. given that _Callback URL_ is configured as `"https://callbacks.yourdomain.com/sinch/callback/ace"`
 
     PartnerApplicationKey = 669E367E-6BBA-48AB-AF15-266871C28135
     PartnerApplicationSecret = BeIukql3pTKJ8RGL5zo0DA==
@@ -259,7 +259,7 @@ E.g. given that _Callback URL_ is configured as `"https://callbacks.yourdomain.c
         REWF+X220L4/Gw1spXOU7g==
         application/json
         x-timestamp:2014-09-24T10:59:41Z
-        /sinch/callback
+        /sinch/callback/ace
 
     Signature = Base64 ( HMAC-SHA256 ( PartnerApplicationSecret, UTF8 (StringToSign ) ) )
         Tg6fMyo8mj9pYfWQ9ssbx3Tc1BNC87IEygAfLbJqZb4=


### PR DESCRIPTION
Fix regression in 247cd7bdbebada05449d6b914ebb17bc2d63a50d (input to
signature can't be changed just like that).

Will follow up with separate MR fixing the sample as a whole,
i.e. fixing both example input and expected output signature.