### PR TITLE
Refer to x-timestamp with consistent casing (lowercase)

### DIFF
--- a/docs/voice/number-administration.md
+++ b/docs/voice/number-administration.md
@@ -42,11 +42,11 @@ When logging in, you should always pass in the header the “number administrati
 > Always use this exact key in the log in step. Do not use any of your app keys.
 
     Authorization: Application 669762D5-2B10-44E0-8418-BC9EE4457555
-    X-Timestamp: {now}
+    x-timestamp: {now}
 
     eg:
     Authorization: Application 669762D5-2B10-44E0-8418-BC9EE4457555
-    X-Timestamp: 2015-06-20T11:43:10.944Z
+    x-timestamp: 2015-06-20T11:43:10.944Z
 
 ### Request
 
@@ -114,11 +114,11 @@ As a second step, you need to create an instance with the ‘authorization’ st
 This is a protected resource and requires a [user signed request](doc:using-rest#user-signed-request).
 
     Authorization: User {authorization}
-    X-Timestamp: {now}
+    x-timestamp: {now}
 
     eg:
     Authorization: User eyJhcHBsaWNhdGlvbktleSI6IllPVVJfQVBQTElDQVRJT05fS0VZIiwiaWRlbnRpdHkiOnsidHlwZSI6ImVtYWlsIiwiZW5kcG9pbnQiOiJhZGRyZXNzQGV4YW1wbGUuY29tIn0sImNyZWF0ZWQiOiIyMDE1LTA2LTI0VDA4OjMyOjMyLjk0MTc2MDVaIn0=:Uc3UQ6tnextCCXiuieizBGNf16SDKFGFWMpu6LKbOwA=
-    X-Timestamp: 2015-06-20T11:43:10.944Z
+    x-timestamp: 2015-06-20T11:43:10.944Z
 
 ### Request
 
@@ -179,11 +179,11 @@ With the instance that you created you can now perform instance signed requests,
 This is a protected resource and requires an [instance signed request](doc:using-rest#instance-signed-request).
 
     Authorization: Instance {instance ID}:{instance signature}
-    X-Timestamp: {now}
+    x-timestamp: {now}
 
     eg:
     Authorization: Instance 00a3ffb1-0808-4dd4-9c7d-e4383d82e445:bb9i9SGuw8mPspPF6WHzIZxw4yQxdOwGaDliMi+IhCU=
-    X-Timestamp: 2015-06-20T11:43:10.944Z
+    x-timestamp: 2015-06-20T11:43:10.944Z
 
 ### Request
 
@@ -231,11 +231,11 @@ This API returns all available numbers, so that you can pick which ones you want
 This is a protected resource and requires an [instance signed request](doc:using-rest#instance-signed-request).
 
     Authorization: Instance {instance ID}:{instance signature}
-    X-Timestamp: {now}
+    x-timestamp: {now}
 
     eg:
     Authorization: Instance 00a3ffb1-0808-4dd4-9c7d-e4383d82e445:jYJQFcgc1uh7DO2uQZyLu7rpxOc3jXjcuQNKWiHFJiI=
-    X-Timestamp: 2015-06-20T11:43:10.944Z
+    x-timestamp: 2015-06-20T11:43:10.944Z
 
 ### Request
 
@@ -339,11 +339,11 @@ To rent numbers, you must first reserve them and then check out. This endpoint a
 This is a protected resource and requires an [instance signed request](doc:using-rest#instance-signed-request).
 
     Authorization: Instance {instance ID}:{instance signature}
-    X-Timestamp: {now}
+    x-timestamp: {now}
 
     eg:
     Authorization: Instance 00a3ffb1-0808-4dd4-9c7d-e4383d82e445:a6p7RYw8bMr3JuZh1LArvWTLJjIgCeQj5nsRZaXW7VQ=
-    X-Timestamp: 2015-06-20T11:43:10.944Z
+    x-timestamp: 2015-06-20T11:43:10.944Z
 
 ### Request
 
@@ -402,11 +402,11 @@ This endpoints allows you to check out the numbers that you have reserved, so th
 This is a protected resource and requires an [instance signed request](doc:using-rest#instance-signed-request).
 
     Authorization: Instance {instance ID}:{instance signature}
-    X-Timestamp: {now}
+    x-timestamp: {now}
 
     eg:
     Authorization: Instance 00a3ffb1-0808-4dd4-9c7d-e4383d82e445:FN0oGGh6UAzdP8WVVwgbhXqUM2KJpHoWgjcgUKpS3bU=
-    X-Timestamp: 2015-06-20T11:43:10.944Z
+    x-timestamp: 2015-06-20T11:43:10.944Z
 
 ### Request
 
@@ -452,11 +452,11 @@ This endpoint lists all the numbers that are assigned to your account.
 This is a protected resource and requires an [instance signed request](doc:using-rest#instance-signed-request).
 
     Authorization: Instance {instance ID}:{instance signature}
-    X-Timestamp: {now}
+    x-timestamp: {now}
 
     eg:
     Authorization: Instance 00a3ffb1-0808-4dd4-9c7d-e4383d82e445:PToDaAs7AiJDqGKZHCl3mayEigGWodVfg4fSlkAYLHg=
-    X-Timestamp: 2015-06-20T11:43:10.944Z
+    x-timestamp: 2015-06-20T11:43:10.944Z
 
 ### Request
 
@@ -543,11 +543,11 @@ This endpoint lists all numbers that are assigned to a particular app.
 This is a protected resource and requires an [instance signed request](doc:using-rest#instance-signed-request).
 
     Authorization: Instance {instance ID}:{instance signature}
-    X-Timestamp: {now}
+    x-timestamp: {now}
 
     eg:
     Authorization: Instance 00a3ffb1-0808-4dd4-9c7d-e4383d82e445:VE1UwyOa8r9DscyBWGVZ43qEDn+SGJGoNe2aN8WrR+8=
-    X-Timestamp: 2015-06-20T11:43:10.944Z
+    x-timestamp: 2015-06-20T11:43:10.944Z
 
 ### Request
 
@@ -628,11 +628,11 @@ A new endpoint to only add a specific number to an application without overwriti
 This is a protected resource and requires an [instance signed request](doc:using-rest#instance-signed-request).
 
     Authorization: Instance {instance ID}:{instance signature}
-    X-Timestamp: {now}
+    x-timestamp: {now}
 
     eg:
     Authorization: Instance 00a3ffb1-0808-4dd4-9c7d-e4383d82e445:6mLYthlkatoYKkq15oI/RuwtC8sIwfJsPrSHkOLDmUM=
-    X-Timestamp: 2015-06-20T11:43:10.944Z
+    x-timestamp: 2015-06-20T11:43:10.944Z
 
 ### Request
 
@@ -727,11 +727,11 @@ With this API you can remove (unassign) a number from your application. They wil
 This is a protected resource and requires an [instance signed request](doc:using-rest#instance-signed-request).
 
     Authorization: Instance {instance ID}:{instance signature}
-    X-Timestamp: {now}
+    x-timestamp: {now}
 
     eg:
     Authorization: Instance 00a3ffb1-0808-4dd4-9c7d-e4383d82e445:EA85F4qGFB0+tYZUh68g22R8DgtzxpsCXttLq1NKPgM=
-    X-Timestamp: 2015-06-20T11:43:10.944Z
+    x-timestamp: 2015-06-20T11:43:10.944Z
 
 ### Request
 

--- a/docs/voice/number-administration/add-numbers-to-an-application-overwrite.md
+++ b/docs/voice/number-administration/add-numbers-to-an-application-overwrite.md
@@ -18,11 +18,11 @@ A new endpoint to only add a specific number to an application without overwriti
 This is a protected resource and requires an [instance signed request](doc:using-rest#instance-signed-request).
 
     Authorization: Instance {instance ID}:{instance signature}
-    X-Timestamp: {now}
+    x-timestamp: {now}
 
     eg:
     Authorization: Instance 00a3ffb1-0808-4dd4-9c7d-e4383d82e445:6mLYthlkatoYKkq15oI/RuwtC8sIwfJsPrSHkOLDmUM=
-    X-Timestamp: 2015-06-20T11:43:10.944Z
+    x-timestamp: 2015-06-20T11:43:10.944Z
 
 ## Request
 
@@ -117,11 +117,11 @@ With this API you can remove (unassign) a number from your application. They wil
 This is a protected resource and requires an [instance signed request](doc:using-rest#instance-signed-request).
 
     Authorization: Instance {instance ID}:{instance signature}
-    X-Timestamp: {now}
+    x-timestamp: {now}
 
     eg:
     Authorization: Instance 00a3ffb1-0808-4dd4-9c7d-e4383d82e445:EA85F4qGFB0+tYZUh68g22R8DgtzxpsCXttLq1NKPgM=
-    X-Timestamp: 2015-06-20T11:43:10.944Z
+    x-timestamp: 2015-06-20T11:43:10.944Z
 
 ## Request
 

--- a/docs/voice/number-administration/checkout-reserved-numbers.md
+++ b/docs/voice/number-administration/checkout-reserved-numbers.md
@@ -13,11 +13,11 @@ This endpoints allows you to check out the numbers that you have reserved, so th
 This is a protected resource and requires an [instance signed request](doc:using-rest#instance-signed-request).
 
     Authorization: Instance {instance ID}:{instance signature}
-    X-Timestamp: {now}
+    x-timestamp: {now}
 
     eg:
     Authorization: Instance 00a3ffb1-0808-4dd4-9c7d-e4383d82e445:FN0oGGh6UAzdP8WVVwgbhXqUM2KJpHoWgjcgUKpS3bU=
-    X-Timestamp: 2015-06-20T11:43:10.944Z
+    x-timestamp: 2015-06-20T11:43:10.944Z
 
 ## Request
 

--- a/docs/voice/number-administration/create-an-instance.md
+++ b/docs/voice/number-administration/create-an-instance.md
@@ -13,11 +13,11 @@ As a second step, you need to create an instance with the ‘authorization’ st
 This is a protected resource and requires a [user signed request](doc:using-rest#user-signed-request).
 
     Authorization: User {authorization}
-    X-Timestamp: {now}
+    x-timestamp: {now}
 
     eg:
     Authorization: User eyJhcHBsaWNhdGlvbktleSI6IllPVVJfQVBQTElDQVRJT05fS0VZIiwiaWRlbnRpdHkiOnsidHlwZSI6ImVtYWlsIiwiZW5kcG9pbnQiOiJhZGRyZXNzQGV4YW1wbGUuY29tIn0sImNyZWF0ZWQiOiIyMDE1LTA2LTI0VDA4OjMyOjMyLjk0MTc2MDVaIn0=:Uc3UQ6tnextCCXiuieizBGNf16SDKFGFWMpu6LKbOwA=
-    X-Timestamp: 2015-06-20T11:43:10.944Z
+    x-timestamp: 2015-06-20T11:43:10.944Z
 
 ## Request
 

--- a/docs/voice/number-administration/get-numbers-assigned-to-an-application.md
+++ b/docs/voice/number-administration/get-numbers-assigned-to-an-application.md
@@ -13,11 +13,11 @@ This endpoint lists all numbers that are assigned to a particular app.
 This is a protected resource and requires an [instance signed request](doc:using-rest#instance-signed-request).
 
     Authorization: Instance {instance ID}:{instance signature}
-    X-Timestamp: {now}
+    x-timestamp: {now}
 
     eg:
     Authorization: Instance 00a3ffb1-0808-4dd4-9c7d-e4383d82e445:VE1UwyOa8r9DscyBWGVZ43qEDn+SGJGoNe2aN8WrR+8=
-    X-Timestamp: 2015-06-20T11:43:10.944Z
+    x-timestamp: 2015-06-20T11:43:10.944Z
 
 ## Request
 

--- a/docs/voice/number-administration/get-numbers-available-to-rent.md
+++ b/docs/voice/number-administration/get-numbers-available-to-rent.md
@@ -13,11 +13,11 @@ This API returns all available numbers, so that you can pick which ones you want
 This is a protected resource and requires an [instance signed request](doc:using-rest#instance-signed-request).
 
     Authorization: Instance {instance ID}:{instance signature}
-    X-Timestamp: {now}
+    x-timestamp: {now}
 
     eg:
     Authorization: Instance 00a3ffb1-0808-4dd4-9c7d-e4383d82e445:jYJQFcgc1uh7DO2uQZyLu7rpxOc3jXjcuQNKWiHFJiI=
-    X-Timestamp: 2015-06-20T11:43:10.944Z
+    x-timestamp: 2015-06-20T11:43:10.944Z
 
 ## Request
 

--- a/docs/voice/number-administration/get-organisation.md
+++ b/docs/voice/number-administration/get-organisation.md
@@ -13,11 +13,11 @@ With the instance that you created you can now perform instance signed requests,
 This is a protected resource and requires an [instance signed request](doc:using-rest#instance-signed-request).
 
     Authorization: Instance {instance ID}:{instance signature}
-    X-Timestamp: {now}
+    x-timestamp: {now}
 
     eg:
     Authorization: Instance 00a3ffb1-0808-4dd4-9c7d-e4383d82e445:bb9i9SGuw8mPspPF6WHzIZxw4yQxdOwGaDliMi+IhCU=
-    X-Timestamp: 2015-06-20T11:43:10.944Z
+    x-timestamp: 2015-06-20T11:43:10.944Z
 
 ## Request
 

--- a/docs/voice/number-administration/list-all-rented-numbers.md
+++ b/docs/voice/number-administration/list-all-rented-numbers.md
@@ -13,11 +13,11 @@ This endpoint lists all the numbers that are assigned to your account.
 This is a protected resource and requires an [instance signed request](doc:using-rest#instance-signed-request).
 
     Authorization: Instance {instance ID}:{instance signature}
-    X-Timestamp: {now}
+    x-timestamp: {now}
 
     eg:
     Authorization: Instance 00a3ffb1-0808-4dd4-9c7d-e4383d82e445:PToDaAs7AiJDqGKZHCl3mayEigGWodVfg4fSlkAYLHg=
-    X-Timestamp: 2015-06-20T11:43:10.944Z
+    x-timestamp: 2015-06-20T11:43:10.944Z
 
 ## Request
 

--- a/docs/voice/number-administration/log-in.md
+++ b/docs/voice/number-administration/log-in.md
@@ -23,11 +23,11 @@ When logging in, you should always pass in the header the “number administrati
 > Always use this exact key in the log in step. Do not use any of your app keys.
 
     Authorization: Application 669762D5-2B10-44E0-8418-BC9EE4457555
-    X-Timestamp: {now}
+    x-timestamp: {now}
 
     eg:
     Authorization: Application 669762D5-2B10-44E0-8418-BC9EE4457555
-    X-Timestamp: 2015-06-20T11:43:10.944Z
+    x-timestamp: 2015-06-20T11:43:10.944Z
 
 ## Request
 

--- a/docs/voice/number-administration/reserve-numbers.md
+++ b/docs/voice/number-administration/reserve-numbers.md
@@ -13,11 +13,11 @@ To rent numbers, you must first reserve them and then check out. This endpoint a
 This is a protected resource and requires an [instance signed request](doc:using-rest#instance-signed-request).
 
     Authorization: Instance {instance ID}:{instance signature}
-    X-Timestamp: {now}
+    x-timestamp: {now}
 
     eg:
     Authorization: Instance 00a3ffb1-0808-4dd4-9c7d-e4383d82e445:a6p7RYw8bMr3JuZh1LArvWTLJjIgCeQj5nsRZaXW7VQ=
-    X-Timestamp: 2015-06-20T11:43:10.944Z
+    x-timestamp: 2015-06-20T11:43:10.944Z
 
 ## Request
 

--- a/docs/voice/using-rest.md
+++ b/docs/voice/using-rest.md
@@ -14,7 +14,7 @@ The client must send a custom header *x-timestamp* (time) with each request that
 
 *Example*
 
-    X-Timestamp: 2014-06-02T15:39:31.2729234Z
+    x-timestamp: 2014-06-02T15:39:31.2729234Z
 
 ### Public Resources
 
@@ -48,7 +48,7 @@ Use the following (pseudocode) to sign a request for the Sinch Platform. The res
 
     Content-MD5 = Base64 ( MD5 ( UTF8 ( [BODY] ) ) )
 
-*CanonicalizedHeaders*: Currently the only header required is “X-Timestamp”.
+*CanonicalizedHeaders*: Currently the only header required is “x-timestamp”.
 
 *CanonicalizedResource* - The resource _path_.
 
@@ -68,7 +68,7 @@ To get the *applicationKey* and *applicationSecret*, you should create an applic
 For the following POST request to the protected resource /v1/sms/+46700000000,
 
     POST /v1/sms/+46700000000
-    X-Timestamp: 2014-06-04T13:41:58Z
+    x-timestamp: 2014-06-04T13:41:58Z
     Content-Type: application/json
 
     {“message”:“Hello world”}
@@ -101,7 +101,7 @@ the signature should be formed like this:
         CanonicalizedHeaders + “\n” +
         CanonicalizedResource;
 
-**CanonicalizedHeaders**: Currently the only header required is “X-Timestamp”.  
+**CanonicalizedHeaders**: Currently the only header required is “x-timestamp”.  
 
 ### Callback Request Signing
 
@@ -201,7 +201,7 @@ In order to increase security and minimize the risk of app secrets to be comprom
 
 *INSTANCE\_SECRET*: INSTANCE\_SECRET is received from ‘\[POST\] /instances’ as a Base64 encoded byte array. It **must** be decoded from Base64 before being used for signing.
 
-*CanonicalizedHeaders* - Currently the only header required is “X-Timestamp”.
+*CanonicalizedHeaders* - Currently the only header required is “x-timestamp”.
 
 *CanonicalizedResource* - The resource _path_.
 
@@ -214,7 +214,7 @@ In order to increase security and minimize the risk of app secrets to be comprom
 
     PUT v1/organisations/id/8888123/numbers/shop HTTP/1.1
     Host: api.sinch.com
-    X-Timestamp: 2015-06-20T11:43:10.944Z
+    x-timestamp: 2015-06-20T11:43:10.944Z
     Content-Type: application/json
 
     {“groupId”:13,“quantity”:1}
@@ -254,7 +254,7 @@ Base64 ( HMAC-SHA256 ( INSTANCE\_SECRET, UTF8( \[STRING\_TO\_SIGN\] ) )
 
     PUT v1/applications/key/bb7b4e39-4227-4913-8c81-2db4abb54fb3/numbers HTTP/1.1
     Host: api.sinch.com
-    X-Timestamp: 2015-06-20T11:43:10.944Z
+    x-timestamp: 2015-06-20T11:43:10.944Z
     Content-Type: application/json
 
     {}


### PR DESCRIPTION
Although HTTP headers are treated case-insensitive, the `x-timestamp: ...` component in the request signature is not, so choose the latter casing when referring to also the HTTP header.