### PR TITLE
RTC (Ocra): Restrict User IDs to URL-safe base64 alphabet

### DIFF
--- a/docs/voice/voice-for-android-cloud/voice-android-cloud-miscellaneous.md
+++ b/docs/voice/voice-for-android-cloud/voice-android-cloud-miscellaneous.md
@@ -22,13 +22,21 @@ The environment is passed as the parameter _environmentHost_ when instantiating 
 
 ## Restrictions on User IDs
 
-User IDs can only contain characters in the _printable ASCII character set_. That is:
+User IDs must only contain URL-safe characters and is restricted to the following character set:
 
 ```text
-    !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~
+ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghjiklmnopqrstuvwxyz0123456789-_=
 ```
 
-User IDs **must not** be longer than **40** characters.
+User IDs **must not** be longer than **255** bytes.
+
+If you really need to use _User IDs_ containing characters outside the
+allowed set above, you could consider _base64_-encoding the raw _User
+IDs_ using a URL-safe base64 alphabet as described in
+https://tools.ietf.org/html/rfc4648#section-5). Please note how the
+allowed character set overlaps with the URL-safe base64 alphabet, but
+does __NOT__ allow characters in the __non__-URL-safe alphabet, e.g. `/`
+(forward slash) and `+` (plus sign).
 
 ## Encryption export regulations
 

--- a/docs/voice/voice-ios-cloud/voice-ios-cloud-miscellaneous.md
+++ b/docs/voice/voice-ios-cloud/voice-ios-cloud-miscellaneous.md
@@ -16,13 +16,21 @@ The _Sinch.framework_ file includes a FAT-binary containing the architectures _a
 
 ## Restrictions on User IDs
 
-User IDs can only contain characters in the _printable ASCII character set_. That is:
+User IDs must only contain URL-safe characters and is restricted to the following character set:
 
 ```text
-!"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~
+ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghjiklmnopqrstuvwxyz0123456789-_=
 ```
 
-User IDs **must not** be longer than **40** characters.
+User IDs **must not** be longer than **255** bytes.
+
+If you really need to use _User IDs_ containing characters outside the
+allowed set above, you could consider _base64_-encoding the raw _User
+IDs_ using a URL-safe base64 alphabet as described in
+https://tools.ietf.org/html/rfc4648#section-5). Please note how the
+allowed character set overlaps with the URL-safe base64 alphabet, but
+does __NOT__ allow characters in the __non__-URL-safe alphabet, e.g. `/`
+(forward slash) and `+` (plus sign).
 
 ## Statistics
 


### PR DESCRIPTION
Clarify restrictions on User IDs:

- URL-safe base64 alphabet.
- New max length is 255 bytes.

RTC-5326