### PR TITLE
Update RTC Android SDK binary size footprint estimates

### DIFF
--- a/docs/voice/voice-for-android-cloud/voice-android-cloud-miscellaneous.md
+++ b/docs/voice/voice-for-android-cloud/voice-android-cloud-miscellaneous.md
@@ -8,6 +8,13 @@ hidden: false
 
 We officially support the 3 latest major Android versions. You can try older versions but there are no guarantees it will work as expected.
 
+## Note on Sinch SDK Size
+
+The _Sinch Android SDK aar_ library includes a common Java library of approximately 900 KB, and four binaries containing the architectures _armv7_, _arm64_, _x86_, and _x86_64_, which size varies from 6.2 MB for _armv7_ to 11.1 MB for _x86_64_, with the _armv64_ having 10.2 MB in size. Combined and compressed in the _aar_ it yields over 17 MB in size. To reduce the footprint, it is highly recommended to use _Android App Bundle_ publishing format (see https://developer.android.com/platform/technology/app-bundle). In that case, only the common Java code and target architecture binary will be included in the final package.
+
+As an example, the rough estimation of typical _arm64_ distribution will have 900 KB + 10.2 MB yielding slightly over 11 MB before compression (which is hard to estimate, but can be assumed within 1x-2x range).
+You can always check your app download and install size in the Google Play Console (https://support.google.com/googleplay/android-developer/answer/9302563)
+
 ## Restrictions on User IDs
 
 User IDs **must not** be longer than **255** bytes, **must** only contain URL-safe characters, and restricted to the following character set:


### PR DESCRIPTION
Update RTC Android SDK binary size footprint estimates, based on build
sinch-android-rtc-4.0.0_f1f95214.zip