### PR TITLE
Add support for callHeaders in ICE, DICE and ConnectMXP

### DIFF
--- a/docs/voice/voice-rest-api/voice-rest-api-callback-api.md
+++ b/docs/voice/voice-rest-api/voice-rest-api-callback-api.md
@@ -574,14 +574,20 @@ Actions allow your Sinch application to control individual calls. The following 
     {
         "name": "connectMXP",
         "destination": {
-        "type": "username",
-        "endpoint": "hello"
-        }
+          "type": "username",
+          "endpoint": "johndoe"
+        },
+        "callHeaders": [
+          {"key": "foo", "value": "bar" },
+          {"key": "baz", "value": "qux" }
+        ]
     }
 
 **connectMXP** is the action of an incoming call event. It allows an app-to-app call to connect.
 
 **destination** is an optional parameter that allows you to specify or override the final call destination.
+
+**callHeaders** is an optional parameter that allows you to specify or override call headers that will be provided to the receiving Sinch SDK client (_callee_). See details [here](doc:voice-rest-api-callback-api#call-headers)
 
 > **Note**
 >
@@ -736,7 +742,6 @@ You can find more information on callback request signing [here](doc:using-rest#
         string - callid
         time - timestamp
         int - version
-        string - custom
         string - user
         money - userRate
         string - cli
@@ -744,6 +749,13 @@ You can find more information on callback request signing [here](doc:using-rest#
         string - domain
         string - applicationKey
         string - originationType
+        CallHeader[] - callHeaders
+    }
+    
+    [CallHeader]
+    {
+      string - key
+      string - value
     }
 
 **event** has the value “ice”
@@ -753,8 +765,6 @@ You can find more information on callback request signing [here](doc:using-rest#
 **timestamp** shows the timestamp of the call
 
 **version** shows the current API version
-
-**custom** is a string that can be used to pass custom information related to the call from Sinch SDK clients. See details [here](doc:voice-rest-api-callback-api#passing-custom-data-from-sinch-sdk-clients-in-callback-events).
 
 **user** shows the user Id that initiated the call
 
@@ -790,6 +800,8 @@ You can find more information on callback request signing [here](doc:using-rest#
 >         "type":"conference",
 >         "endpoint":"myCoolConference"
 >     }
+
+**callHeaders** If the call is initiated by a Sinch SDK Client, call headers will be the headers specified by the _caller_ client. See details [here](doc:voice-rest-api-callback-api#call-headers)
 
 ### Response
 
@@ -859,7 +871,6 @@ You can find more information on callback request signing [here](doc:using-rest#
         string - callid
         time - timestamp
         int - version
-        string - custom
         string - user
     }
 
@@ -870,8 +881,6 @@ You can find more information on callback request signing [here](doc:using-rest#
 **timestamp** shows the timestamp of the call
 
 **version** shows the current API version
-
-**custom** is a string that can be used to pass custom information related to the call from Sinch SDK clients. See details [here](doc:voice-rest-api-callback-api#passing-custom-data-from-sinch-sdk-clients-in-callback-events).
 
 **user** shows the user Id that initiated the call
 
@@ -906,13 +915,19 @@ You can find more information on callback request signing [here](doc:using-rest#
         string - reason
         string - result
         int - version
-        string - custom
         string - user
         money - debit
         money - userRate
         identity - to
         int - duration
         string - from
+        CallHeader[] - callHeaders
+    }
+    
+    [CallHeader]
+    {
+      string - key
+      string - value
     }
 
 **event** has the value “dice”
@@ -942,8 +957,6 @@ You can find more information on callback request signing [here](doc:using-rest#
 
 **version** shows the current API version.
 
-**custom** is a string that can be used to pass custom information related to the call from Sinch SDK clients. See details [here](doc:voice-rest-api-callback-api#passing-custom-data-from-sinch-sdk-clients-in-callback-events).
-
 **user** shows the user Id that initiated the call.
 
 **debit** contains the amount that was charged for the call.
@@ -955,6 +968,8 @@ You can find more information on callback request signing [here](doc:using-rest#
 **duration** shows the duration of the call.
 
 **from** shows information of the initiator of the call.
+
+**callHeaders** is the call headers specified by an initiating Sinch SDK Client, or headers specified in a `connectMXP` action in a ICE response.
 
 ### Response
 
@@ -1079,14 +1094,58 @@ You can find more information on callback request signing [here](doc:using-rest#
     40001 - Illegal SVAML
     50000 - Internal error
 
-## Passing Custom Data From Sinch SDK Clients in Callback Events
+## Call Headers
 
-The _ICE_ and _DICE_ events have a field named `custom` that can be used to pass custom information related to a call from the Sinch SDK clients and made accessible in the callback events. A call can on the client-side be initiated with _headers_ (__[1]__) and `custom` will be populated with the JSON encoding of those headers. E.g. if a call is initiated with headers `{"foo": "x"}` then the value of `custom` will be `"{\"foo\":\"x\"}"`.
+_Call Headers_ can be used to pass custom data from a Sinch SDK client to another, or specified in an _ICE_ response to be made available to the receiving client. Further, if _Call Headers_ is specified they will be available in _ICE_ and _DICE_ events.
+
+Example use cases:
+
+- Specify call headers at call initiation in end-user application (via Sinch SDK client) to make them available to _callee_ client.
+- Specify call headers in ICE response to make them available to _callee_ client.
+
+### Specifying Call Headers in Sinch SDK Clients (iOS & Android)
+
+If the custom data is available with the initiating client and you want to make it available to the receiving client and in ICE and DICE events, pass call headers when initiating the calls using the following Sinch SDK APIs:
+
+- Android: `CallClient.call(String userId, Map<String,String> headers)`
+- iOS: `-[SINCallClient callUserWithId:headers:]`
+
+This will make the call headers available in _ICE_ and _DICE_ events (as `callHeaders`), and on the call objects in the Sinch SDKs (`Call.headers` on Android, `-[SINCall headers]` on iOS).
+
+### Specifying Call Headers in ICE response
+
+You can provide call headers in the ICE response as part of an _action_, e.g. `connectMXP`. This will make the call headers available to the callee client and in the _DICE_ event.
+
+Example of ICE response:
+
+```
+{
+  "action": {
+    "name": "connectMXP",
+    "callHeaders": [
+      {"key": "foo", "value": "bar" },
+      {"key": "baz", "value": "qux" }
+    ]
+  }
+}
+```
+
+The maximum size for the value of call headers is 1024 bytes (counted as the UTF-8 encoded size of each header key/value pair).
+
+> **Important**
+> 
+> When call headers are specified in ICE response, they will be made available to callee, but not to caller. I.e. if call headers was specified first by caller client, but then overriden via ICE response, the caller will not be updated of the changed call headers.
+
+### Call Headers and the `custom` Field
+
+__WARNING__: This is a deprecated feature.
+
+The _ICE_ and _DICE_ events have a field named `custom`. If call headers are specified at call initation on SDK client or via ICE response, the call headers will be available in the `custom` in a JSON encoded format. E.g. if a call is initiated with headers `{"foo": "x"}` then the value of `custom` will be `"{\"foo\":\"x\"}"`.
+
+Note that call headers are only mapped to `custom` for Sinch SDK client calls and it is considered a legacy feature. It is *strongly recommended* to use `callHeaders` as specify/override call headers in _ICE_ and _DICE_.
 
 > **Important**
 >
 > The value type of `custom` is always a _string_ and the JSON-encoded representation of _headers_ will be escaped when the string value is part of the larger ICE event structure. I.e. from the perspective of the structure of the ICE-event, the value of `custom` is just an opaque string.
 
 The maximum size for the value of `custom` is 1024 bytes.
-
-__[1]__: E.g. `CallClient.call(String userId, Map<String,String> headers)` in the Sinch Android APIs, and `-[SINCallClient callUserWithId:headers:]` in the Sinch iOS APIs.

--- a/docs/voice/voice-rest-api/voice-rest-api-callback-api.md
+++ b/docs/voice/voice-rest-api/voice-rest-api-callback-api.md
@@ -978,7 +978,7 @@ You can find more information on callback request signing [here](doc:using-rest#
 
 **from** shows information of the initiator of the call.
 
-**callHeaders** is the call headers specified by an initiating Sinch SDK Client, or headers specified in a `connectMXP` action in a ICE response.
+**callHeaders** is the call headers specified by an initiating Sinch SDK Client, or headers specified in a `connectMXP` action in the ICE response.
 
 ### Response
 

--- a/docs/voice/voice-rest-api/voice-rest-api-callback-api.md
+++ b/docs/voice/voice-rest-api/voice-rest-api-callback-api.md
@@ -742,6 +742,7 @@ You can find more information on callback request signing [here](doc:using-rest#
         string - callid
         time - timestamp
         int - version
+        string - custom
         string - user
         money - userRate
         string - cli
@@ -765,6 +766,8 @@ You can find more information on callback request signing [here](doc:using-rest#
 **timestamp** shows the timestamp of the call
 
 **version** shows the current API version
+
+**custom** is a string that can be used to pass custom information related to the call.
 
 **user** shows the user Id that initiated the call
 
@@ -871,6 +874,7 @@ You can find more information on callback request signing [here](doc:using-rest#
         string - callid
         time - timestamp
         int - version
+        string - custom
         string - user
     }
 
@@ -881,6 +885,8 @@ You can find more information on callback request signing [here](doc:using-rest#
 **timestamp** shows the timestamp of the call
 
 **version** shows the current API version
+
+**custom** is a string that can be used to pass custom information related to the call.
 
 **user** shows the user Id that initiated the call
 
@@ -915,6 +921,7 @@ You can find more information on callback request signing [here](doc:using-rest#
         string - reason
         string - result
         int - version
+        string - custom
         string - user
         money - debit
         money - userRate
@@ -956,6 +963,8 @@ You can find more information on callback request signing [here](doc:using-rest#
 > - “FAILED”
 
 **version** shows the current API version.
+
+**custom** is a string that can be used to pass custom information related to the call.
 
 **user** shows the user Id that initiated the call.
 

--- a/docs/voice/voice-rest-api/voice-rest-api-callback-api.md
+++ b/docs/voice/voice-rest-api/voice-rest-api-callback-api.md
@@ -1149,7 +1149,7 @@ The maximum size for the value of call headers is 1024 bytes (counted as the UTF
 
 __WARNING__: This is a deprecated feature.
 
-The _ICE_ and _DICE_ events have a field named `custom`. If call headers are specified at call initation on SDK client or via ICE response, the call headers will be available in the `custom` in a JSON encoded format. E.g. if a call is initiated with headers `{"foo": "x"}` then the value of `custom` will be `"{\"foo\":\"x\"}"`.
+The _ICE_ and _DICE_ events have a field named `custom`. If call headers are specified at call initation on SDK client or via ICE response, the call headers will be available in `custom` in a JSON encoded format. E.g. if a call is initiated with headers `{"foo": "x"}` then the value of `custom` will be `"{\"foo\":\"x\"}"`.
 
 Note that call headers are only mapped to `custom` for Sinch SDK client calls and it is considered a legacy feature. It is *strongly recommended* to use `callHeaders` as specify/override call headers in _ICE_ and _DICE_.
 

--- a/docs/voice/voice-rest-api/voice-rest-api-callback-api_2.md
+++ b/docs/voice/voice-rest-api/voice-rest-api-callback-api_2.md
@@ -763,7 +763,7 @@ You can find more information on callback request signing [here](doc:using-rest#
 
 **version** shows the current API version
 
-**custom** is a string that can be used to pass custom information related to the call from Sinch SDK clients. See details [here](doc:voice-rest-api-callback-api#passing-custom-data-from-sinch-sdk-clients-in-callback-events).
+**custom** is a string that can be used to pass custom information related to the call from Sinch SDK clients. See details [here](doc:voice-rest-api-callback-api#call-headers).
 
 **user** shows the user Id that initiated the call
 
@@ -880,7 +880,7 @@ You can find more information on callback request signing [here](doc:using-rest#
 
 **version** shows the current API version
 
-**custom** is a string that can be used to pass custom information related to the call from Sinch SDK clients. See details [here](doc:voice-rest-api-callback-api#passing-custom-data-from-sinch-sdk-clients-in-callback-events).
+**custom** is a string that can be used to pass custom information related to the call from Sinch SDK clients. See details [here](doc:voice-rest-api-callback-api#call-headers).
 
 **user** shows the user Id that initiated the call
 
@@ -951,7 +951,7 @@ You can find more information on callback request signing [here](doc:using-rest#
 
 **version** shows the current API version.
 
-**custom** is a string that can be used to pass custom information related to the call from Sinch SDK clients. See details [here](doc:voice-rest-api-callback-api#passing-custom-data-from-sinch-sdk-clients-in-callback-events).
+**custom** is a string that can be used to pass custom information related to the call from Sinch SDK clients. See details [here](doc:voice-rest-api-callback-api#call-headers).
 
 **user** shows the user Id that initiated the call.
 


### PR DESCRIPTION
Call headers is added as a first-class field in ICE, DICE and
connectMXP action. This provides two improvements:

- Allows a cleaner way to expose call headers (not wrapped in `custom`
  which entails nested JSON encoding etc.)
- Allows a developer to specify call headers in ICE response (in
  `connectMXP` action) to then be made available to callee client.

Mark use of `custom` field as deprecated (in context of ICE, DICE and
MXP calling). (`custom` field is still documented for NEC).

- Remove `custom` field in ICE and DICE request body sections. The
  purpose of this removal is to put emphasis on new `callHeaders`
  support so people don't mix them up, and use `callHeaders` going forward.
- Add new section on `custom` being deprecated and its relation to
- call headers.

Fix example username (hello -> johndoe)

RTC-5463