### PR TITLE
Separate encoding + add billing implication

### DIFF
--- a/docs/sms/sms-guide.md
+++ b/docs/sms/sms-guide.md
@@ -804,7 +804,7 @@ The following characters are also available, but they are counted as two charact
 
 ##### Other Characters
 
-If other characters are required for different languages, 16-bit Unicode (UCS-2) encoding will be used. When using UCS-2 encoding, each character will take 2 bytes, which means up to 70 characters can be sent per UCS-2 encoded SMS message.
+If other characters are required for different languages, 16-bit Unicode (UCS-2) encoding will be used. When using UCS-2 encoding, each character will take 2 bytes, which means up to 70 characters can be sent per UCS-2 encoded SMS message. Here is more information on this topic, including billing implications.
 
 ### Long Messages
 


### PR DESCRIPTION
This page is just too long. I think many topics can be extracted into their own pages. For example -the topic of encoding. And also include billing implications of a message being split into multiple segments. Twilio reference article here: https://www.twilio.com/docs/sms/tutorials/sending-international-sms-guide#encoding-type-gsm-7-vs-ucs-2