### PR TITLE
Add "camera permissions" on Android video first setup page.

### DIFF
--- a/docs/video/video-for-android/video-android-first-time-setup.md
+++ b/docs/video/video-for-android/video-android-first-time-setup.md
@@ -50,6 +50,7 @@ A minimum set of permissions are needed for the app to use the Sinch SDK. These 
 <uses-permission android:name="android.permission.RECORD_AUDIO" />
 <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
 <uses-permission android:name="android.permission.READ_PHONE_STATE" />
+<uses-permission android:name="android.permission.CAMERA"/>
 ```
 
 > **Note**

--- a/docs/video/video-for-android/video-android-first-time-setup.md
+++ b/docs/video/video-for-android/video-android-first-time-setup.md
@@ -50,7 +50,6 @@ A minimum set of permissions are needed for the app to use the Sinch SDK. These 
 <uses-permission android:name="android.permission.RECORD_AUDIO" />
 <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
 <uses-permission android:name="android.permission.READ_PHONE_STATE" />
-<uses-permission android:name="android.permission.CAMERA"/>
 ```
 
 > **Note**


### PR DESCRIPTION
Hi 
Please can we add the camera permissions to the Android video first setup page.
Sorry first attempt a bit messy. Reverted first two attempts.